### PR TITLE
Create 2019-03-06-00-Add_Triggers_To_LandblockInstance.sql

### DIFF
--- a/Database/2-BaseUpdates/2019-03-06-00-Add_Triggers_To_LandblockInstance.sql
+++ b/Database/2-BaseUpdates/2019-03-06-00-Add_Triggers_To_LandblockInstance.sql
@@ -1,0 +1,27 @@
+USE `ace_world`;
+
+DROP TRIGGER IF EXISTS `landblock_instance_BEFORE_INSERT`;
+
+DELIMITER $$
+CREATE DEFINER = CURRENT_USER TRIGGER `landblock_instance_BEFORE_INSERT` BEFORE INSERT ON `landblock_instance` FOR EACH ROW
+BEGIN
+	IF !(NEW.guid >= 0x70000000 && NEW.guid <= 0x7FFFFFFF)
+	THEN
+		-- don't allow the insert to happen
+		SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = "Cannot add row: guid column value must be between 0x70000000 and 0x7FFFFFFF";
+	END IF;
+END$$
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS `landblock_instance_BEFORE_UPDATE`;
+
+DELIMITER $$
+CREATE DEFINER = CURRENT_USER TRIGGER `landblock_instance_BEFORE_UPDATE` BEFORE UPDATE ON `landblock_instance` FOR EACH ROW
+BEGIN
+	IF !(NEW.guid >= 0x70000000 && NEW.guid <= 0x7FFFFFFF)
+	THEN
+		-- don't allow the insert to happen
+		SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = "Cannot update row: guid column value must be between 0x70000000 and 0x7FFFFFFF";
+	END IF;
+END$$
+DELIMITER ;


### PR DESCRIPTION
Do not allow guids to exist outside of static range for the landblock_instances table

Co-authored-by: Mag-nus <Mag-nus@users.noreply.github.com>